### PR TITLE
chore: Add typescript definition file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.{ts,js,json}]
+indent_style = space
+indent_size = 2

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,47 @@
+
+interface Options {
+  /**
+   * If a PowerShell script should be created.
+   *
+   * @default true
+   */
+  createPwshFile?: boolean;
+
+  /**
+   * If a Windows Command Prompt script should be created.
+   *
+   * @default false
+   */
+  createCmdFile?: boolean;
+
+  /**
+   * If symbolic links should be preserved.
+   *
+   * @default false
+   */
+  preserveSymlinks?: boolean;
+
+  /**
+   * The path to the executable file.
+   */
+  prog?: string;
+
+  /**
+   * The arguments to initialize the `node` process with.
+   */
+  args?: string;
+
+  /**
+   * The value of the $NODE_PATH environment variable.
+   *
+   * The single `string` format is only kept for legacy compatibility,
+   * and the array form should be preferred.
+   */
+  nodePath?: string | string[];
+}
+
+declare function cmdShim(src: string, to: string, opts: Options): Promise<void>
+declare namespace cmdShim {
+  function cmdShimIfExists(src: string, to: string, opts: Options): Promise<void>
+}
+export = cmdShim;

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function chmodShim (to, {createCmdFile, createPwshFile}) {
 }
 
 /**
- * @param {string} nodePath
+ * @param {string|string[]} nodePath
  * @returns {{win32:string,posix:string}}
  */
 function normalizePathEnvVar (nodePath) {
@@ -251,7 +251,7 @@ function normalizePathEnvVar (nodePath) {
       posix: nodePath
     }
   }
-  let split = (typeof nodePath === 'string' ? String(nodePath).split(path.delimiter) : Array.from(nodePath))
+  let split = (typeof nodePath === 'string' ? nodePath.split(path.delimiter) : Array.from(nodePath))
   let result = {}
   for (let i = 0; i < split.length; i++) {
     const win32 = split[i].split('/').join('\\')

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "md": "mos"
   },
   "files": [
+    "index.d.ts",
     "index.js"
   ],
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/pnpm/cmd-shim.git"


### PR DESCRIPTION
This PR adds a TypeScript definition file to the project, allowing `@pnpm/link‑bins` to remove the `declare module '@zkochan/cmd‑shim'` pseudo‑definition from [the `typings/index.d.ts` file](https://github.com/pnpm/link-bins/blob/962fcedaf6e4a24571e307a7c7f0b4b7e84d0126/typings/index.d.ts#L11-L14).