### PR TITLE
Refactor cmdShim_ and writeShim(_)

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,16 @@ function writeShimPost (target) {
   return chmodShim(target)
 }
 
+/**
+ * Look into runtime (e.g. `node` & `sh` & `pwsh`) and its arguments
+ * of the target program (script or executable).
+ *
+ * @param {string} target Path to the executable or script.
+ * @typedef {{program?: string, additionalArgs: string}} RuntimeInfo If `.program` is `null`,
+ * the program may be a binary executable or something and can be called from shells by just its path.
+ * (e.g. `.\foo.exe` in CMD or PowerShell)
+ * @return {Promise<RuntimeInfo>} Promise of infomation of runtime of `target`.
+ */
 function searchScriptRuntime (target) {
   return fs
     .readFile(target, 'utf8')

--- a/index.js
+++ b/index.js
@@ -102,6 +102,11 @@ function writeShimPre (target) {
   return rm(target).then(() => mkdir(path.dirname(target)))
 }
 
+/**
+ * Do processes after writing the shim.
+ *
+ * @param {string} target Path to just created shim.
+ */
 function writeShimPost (target) {
   // Only chmoding shims as of now.
   // Some other processes may be appended.
@@ -364,6 +369,7 @@ function generatePwshShim (src, to, opts) {
 
   return pwsh
 }
+
 
 function chmodShim (to) {
   return fs.chmod(to, 0o755)

--- a/index.js
+++ b/index.js
@@ -225,24 +225,22 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
  * @return {string} The content of shim.
  */
 function generateCmdShim (src, to, opts) {
-  let shTarget = path.relative(path.dirname(to), src)
+  // `shTarget` is not used to generate the content.
+  const shTarget = path.relative(path.dirname(to), src)
   let target = shTarget.split('/').join('\\')
   let longProg
   let prog = opts.prog
-  shTarget = shTarget.split('\\').join('/')
   let args = opts.args || ''
-  let {
+  const {
     win32: nodePath
   } = normalizePathEnvVar(opts.nodePath)
   if (!prog) {
     prog = `"%~dp0\\${target}"`
     args = ''
     target = ''
-    shTarget = ''
   } else {
     longProg = `"%~dp0\\${prog}.exe"`
     target = `"%~dp0\\${target}"`
-    shTarget = `"$basedir/${shTarget}"`
   }
 
   // @IF EXIST "%~dp0\node.exe" (
@@ -279,24 +277,19 @@ function generateCmdShim (src, to, opts) {
  */
 function generateShShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
-  let target = shTarget.split('/').join('\\')
-  let prog = opts.prog
-  let shProg = prog && prog.split('\\').join('/')
+  let shProg = opts.prog && opts.prog.split('\\').join('/')
   let shLongProg
   shTarget = shTarget.split('\\').join('/')
   let args = opts.args || ''
-  let {
+  const {
     posix: shNodePath
   } = normalizePathEnvVar(opts.nodePath)
-  if (!prog) {
-    prog = `"%~dp0\\${target}"`
+  if (!shProg) {
     shProg = `"$basedir/${shTarget}"`
     args = ''
-    target = ''
     shTarget = ''
   } else {
-    shLongProg = '"$basedir/' + prog + '"'
-    target = `"%~dp0\\${target}"`
+    shLongProg = `"$basedir/${opts.prog}"`
     shTarget = `"$basedir/${shTarget}"`
   }
 
@@ -355,10 +348,7 @@ function generateShShim (src, to, opts) {
  */
 function generatePwshShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
-  let target = shTarget.split('/').join('\\')
-  let prog = opts.prog
-  let shProg = prog && prog.split('\\').join('/')
-  let shLongProg
+  const shProg = opts.prog && opts.prog.split('\\').join('/')
   let pwshProg = shProg && `"${shProg}$exe"`
   let pwshLongProg
   shTarget = shTarget.split('\\').join('/')
@@ -367,17 +357,12 @@ function generatePwshShim (src, to, opts) {
     win32: nodePath,
     posix: shNodePath
   } = normalizePathEnvVar(opts.nodePath)
-  if (!prog) {
-    prog = `"%~dp0\\${target}"`
-    shProg = `"$basedir/${shTarget}"`
-    pwshProg = shProg
+  if (!pwshProg) {
+    pwshProg = `"$basedir/${shTarget}"`
     args = ''
-    target = ''
     shTarget = ''
   } else {
-    shLongProg = '"$basedir/' + prog + '"'
-    pwshLongProg = `"$basedir/${prog}$exe"`
-    target = `"%~dp0\\${target}"`
+    pwshLongProg = `"$basedir/${opts.prog}$exe"`
     shTarget = `"$basedir/${shTarget}"`
   }
 
@@ -417,7 +402,7 @@ function generatePwshShim (src, to, opts) {
       '}'
   }
   pwsh += '\n'
-  if (shLongProg) {
+  if (pwshLongProg) {
     pwsh = pwsh +
       '$ret=0\n' +
       `if (Test-Path ${pwshLongProg}) {\n` +

--- a/index.js
+++ b/index.js
@@ -197,7 +197,6 @@ function searchScriptRuntime (target) {
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the (sh) shim(s) that is going to be created.
  * @param {RuntimeInfo} srcRuntimeInfo Result of `await searchScriptRuntime(src)`.
- * @typedef {(src: string, to: string, opts: Options) => string} ShimGenerator
  * @param {ShimGenerator} generateShimScript Generator of shim script.
  * @param {Options} opts Other options.
  */
@@ -215,6 +214,15 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
     .then(() => fs.writeFile(to, generateShimScript(src, to, opts), 'utf8'))
     .then(() => writeShimPost(to))
 }
+
+/**
+ * Callback functions to generate scripts for shims.
+ * @callback ShimGenerator
+ * @param {string} src Path to the executable or script.
+ * @param {string} to Path to the shim(s) that is going to be created.
+ * @param {Options} opts Options.
+ * @return {string} Generated script for shim.
+ */
 
 /**
  * Generate the content of a shim for CMD.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,13 @@ const DEFAULT_OPTIONS = {
   createPwshFile: true,
   createCmdFile: isWindows()
 }
+const extensionToProgramMap = new Map([
+  ['.js', 'node'],
+  ['.cmd', 'cmd'],
+  ['.bat', 'cmd'],
+  ['.ps1', 'pwsh'], // not 'powershell'
+  ['.sh', 'sh']
+])
 
 /**
  * Try to create shims.
@@ -72,88 +79,140 @@ function rm (path) {
 }
 
 function cmdShim_ (src, to, opts) {
-  return Promise.all([
-    rm(to),
-    rm(`${to}.ps1`),
-    opts.createCmdFile && rm(`${to}.cmd`)
-  ])
-    .then(() => writeShim(src, to, opts))
+  opts = Object.assign({}, DEFAULT_OPTIONS, opts)
+  return searchScriptRuntime(src).then((srcRuntimeInfo) => {
+    // Always tries to create all types of shims by calling `writeAllShims` as of now.
+    // Append your code here to change the behavior in response to `srcRuntimeInfo`.
+
+    // Create 3 shims for (Ba)sh in Cygwin / MSYS, no extension) & CMD (.cmd) & PowerShell (.ps1)
+    return writeAllShims(src, to, srcRuntimeInfo, opts)
+  })
 }
 
-function writeShim (src, to, opts) {
+function writeAllShims (src, to, srcRuntimeInfo, opts) {
   opts = Object.assign({}, DEFAULT_OPTIONS, opts)
-  const defaultArgs = opts.preserveSymlinks ? '--preserve-symlinks' : ''
-  // make a cmd file and a sh script
-  // First, check if the bin is a #! of some sort.
-  // If not, then assume it's something that'll be compiled, or some other
-  // sort of script, and just call it directly.
-  return mkdir(path.dirname(to))
-    .then(() => {
-      return fs.readFile(src, 'utf8')
-        .then(data => {
-          const firstLine = data.trim().split(/\r*\n/)[0]
-          const shebang = firstLine.match(shebangExpr)
-          if (!shebang) return writeShim_(src, to, Object.assign({}, opts, {args: defaultArgs}))
-          const prog = shebang[1]
-          const args = (shebang[2] && ((defaultArgs && (shebang[2] + ' ' + defaultArgs)) || shebang[2])) || defaultArgs
-          return writeShim_(src, to, Object.assign({}, opts, {prog, args}))
+  return Promise.all([
+    [generateShShim, '', true],
+    [generateCmdShim, '.cmd', opts.createCmdFile],
+    [generatePwshShim, '.ps1', opts.createPwshFile]
+  ].map(([generateShimScript, extension, shouldCreate]) => shouldCreate && writeShim(src, to + extension, srcRuntimeInfo, generateShimScript, opts)))
+}
+
+function writeShimPre (target) {
+  return rm(target).then(() => mkdir(path.dirname(target)))
+}
+
+function writeShimPost (target) {
+  // Only chmoding shims as of now.
+  // Some other processes may be appended.
+  return chmodShim(target)
+}
+
+function searchScriptRuntime (target) {
+  return fs
+    .readFile(target, 'utf8')
+    .then(data => {
+      // First, check if the bin is a #! of some sort.
+      const firstLine = data.trim().split(/\r*\n/)[0]
+      const shebang = firstLine.match(shebangExpr)
+      if (!shebang) {
+        // If not, infer script type from its extension.
+        // If the inferrence fails, it's something that'll be compiled, or some other
+        // sort of script, and just call it directly.
+        const targetExtension = path.extname(target).toLowerCase()
+        return Promise.resolve({
+          // undefined if extension is unknown but it's converted to null.
+          program: extensionToProgramMap.get(targetExtension) || null,
+          additionalArgs: ''
         })
-        .catch(() => writeShim_(src, to, Object.assign({}, opts, {args: defaultArgs})))
+      }
+      return Promise.resolve({
+        program: shebang[1],
+        additionalArgs: shebang[2]
+      })
     })
 }
 
-function writeShim_ (src, to, opts) {
-  opts = Object.assign({}, DEFAULT_OPTIONS, opts)
+function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
+  const defaultArgs = opts.preserveSymlinks ? '--preserve-symlinks' : ''
+  // `Array.prototype.flter` removes ''.
+  // ['--foo', '--bar'].join(' ') and [].join(' ') returns '--foo --bar' and '' respectively.
+  const args = [srcRuntimeInfo.additionalArgs, defaultArgs].filter(arg => arg).join(' ')
+  opts = Object.assign({}, opts, {
+    prog: srcRuntimeInfo.program,
+    args: args
+  })
+
+  return writeShimPre(to)
+    .then(() => fs.writeFile(to, generateShimScript(src, to, opts), 'utf8'))
+    .then(() => writeShimPost(to))
+}
+
+function generateCmdShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
   let target = shTarget.split('/').join('\\')
   let longProg
   let prog = opts.prog
-  let shProg = prog && prog.split('\\').join('/')
-  let shLongProg
-  let pwshProg = shProg && `"${shProg}$exe"`
-  let pwshLongProg
   shTarget = shTarget.split('\\').join('/')
   let args = opts.args || ''
   let {
-    win32: nodePath,
-    posix: shNodePath
+    win32: nodePath
   } = normalizePathEnvVar(opts.nodePath)
   if (!prog) {
     prog = `"%~dp0\\${target}"`
-    shProg = `"$basedir/${shTarget}"`
-    pwshProg = shProg
     args = ''
     target = ''
     shTarget = ''
   } else {
     longProg = `"%~dp0\\${prog}.exe"`
-    shLongProg = '"$basedir/' + prog + '"'
-    pwshLongProg = `"$basedir/${prog}$exe"`
     target = `"%~dp0\\${target}"`
     shTarget = `"$basedir/${shTarget}"`
   }
 
-  let cmd
-  if (opts.createCmdFile) {
-    // @IF EXIST "%~dp0\node.exe" (
-    //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
-    // ) ELSE (
-    //   SETLOCAL
-    //   SET PATHEXT=%PATHEXT:;.JS;=;%
-    //   node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
-    // )
-    cmd = nodePath ? `@SET NODE_PATH=${nodePath}\r\n` : ''
-    if (longProg) {
-      cmd += '@IF EXIST ' + longProg + ' (\r\n' +
-        '  ' + longProg + ' ' + args + ' ' + target + ' %*\r\n' +
-        ') ELSE (\r\n' +
-        '  @SETLOCAL\r\n' +
-        '  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
-        '  ' + prog + ' ' + args + ' ' + target + ' %*\r\n' +
-        ')'
-    } else {
-      cmd += `@${prog} ${args} ${target} %*\r\n`
-    }
+  // @IF EXIST "%~dp0\node.exe" (
+  //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  // ) ELSE (
+  //   SETLOCAL
+  //   SET PATHEXT=%PATHEXT:;.JS;=;%
+  //   node "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
+  // )
+  let cmd = nodePath ? `@SET NODE_PATH=${nodePath}\r\n` : ''
+  if (longProg) {
+    cmd += '@IF EXIST ' + longProg + ' (\r\n' +
+      '  ' + longProg + ' ' + args + ' ' + target + ' %*\r\n' +
+      ') ELSE (\r\n' +
+      '  @SETLOCAL\r\n' +
+      '  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
+      '  ' + prog + ' ' + args + ' ' + target + ' %*\r\n' +
+      ')'
+  } else {
+    cmd += `@${prog} ${args} ${target} %*\r\n`
+  }
+
+  return cmd
+}
+
+function generateShShim (src, to, opts) {
+  let shTarget = path.relative(path.dirname(to), src)
+  let target = shTarget.split('/').join('\\')
+  let prog = opts.prog
+  let shProg = prog && prog.split('\\').join('/')
+  let shLongProg
+  shTarget = shTarget.split('\\').join('/')
+  let args = opts.args || ''
+  let {
+    posix: shNodePath
+  } = normalizePathEnvVar(opts.nodePath)
+  if (!prog) {
+    prog = `"%~dp0\\${target}"`
+    shProg = `"$basedir/${shTarget}"`
+    args = ''
+    target = ''
+    shTarget = ''
+  } else {
+    shLongProg = '"$basedir/' + prog + '"'
+    target = `"%~dp0\\${target}"`
+    shTarget = `"$basedir/${shTarget}"`
   }
 
   // #!/bin/sh
@@ -195,6 +254,37 @@ function writeShim_ (src, to, opts) {
   } else {
     sh = sh + env + shProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
       'exit $?\n'
+  }
+
+  return sh
+}
+
+function generatePwshShim (src, to, opts) {
+  let shTarget = path.relative(path.dirname(to), src)
+  let target = shTarget.split('/').join('\\')
+  let prog = opts.prog
+  let shProg = prog && prog.split('\\').join('/')
+  let shLongProg
+  let pwshProg = shProg && `"${shProg}$exe"`
+  let pwshLongProg
+  shTarget = shTarget.split('\\').join('/')
+  let args = opts.args || ''
+  let {
+    win32: nodePath,
+    posix: shNodePath
+  } = normalizePathEnvVar(opts.nodePath)
+  if (!prog) {
+    prog = `"%~dp0\\${target}"`
+    shProg = `"$basedir/${shTarget}"`
+    pwshProg = shProg
+    args = ''
+    target = ''
+    shTarget = ''
+  } else {
+    shLongProg = '"$basedir/' + prog + '"'
+    pwshLongProg = `"$basedir/${prog}$exe"`
+    target = `"%~dp0\\${target}"`
+    shTarget = `"$basedir/${shTarget}"`
   }
 
   // #!/usr/bin/env pwsh
@@ -252,20 +342,11 @@ function writeShim_ (src, to, opts) {
       'exit $LASTEXITCODE\n'
   }
 
-  return Promise.all([
-    opts.createCmdFile && fs.writeFile(to + '.cmd', cmd, 'utf8'),
-    opts.createPwshFile && fs.writeFile(`${to}.ps1`, pwsh, 'utf8'),
-    fs.writeFile(to, sh, 'utf8')
-  ])
-    .then(() => chmodShim(to, opts))
+  return pwsh
 }
 
-function chmodShim (to, {createCmdFile, createPwshFile}) {
-  return Promise.all([
-    fs.chmod(to, 0o755),
-    createPwshFile && fs.chmod(`${to}.ps1`, 0o755),
-    createCmdFile && fs.chmod(`${to}.cmd`, 0o755)
-  ])
+function chmodShim (to) {
+  return fs.chmod(to, 0o755)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ function writeShimsPreCommon (target) {
  */
 function writeAllShims (src, to, srcRuntimeInfo, opts) {
   opts = Object.assign({}, DEFAULT_OPTIONS, opts)
+  /** @type {Array<[ShimGenerator, string]>} */
   const generatorAndExtPairs = [[generateShShim, '']]
   if (opts.createCmdFile) {
     generatorAndExtPairs.push([generateCmdShim, '.cmd'])

--- a/index.js
+++ b/index.js
@@ -98,6 +98,11 @@ function writeAllShims (src, to, srcRuntimeInfo, opts) {
   ].map(([generateShimScript, extension, shouldCreate]) => shouldCreate && writeShim(src, to + extension, srcRuntimeInfo, generateShimScript, opts)))
 }
 
+/**
+ * Do processes before writing shim.
+ *
+ * @param {string} target Path to shim that is going to be created.
+ */
 function writeShimPre (target) {
   return rm(target).then(() => mkdir(path.dirname(target)))
 }

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.cmd` (or `.bat`).
- * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @param {Options} opts Options.
  * @return {string} The content of shim.
  */
 function generateCmdShim (src, to, opts) {

--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ function generateCmdShim (src, to, opts) {
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.sh` or to contain no extension.
- * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @param {Options} opts Options.
  * @return {string} The content of shim.
  */
 function generateShShim (src, to, opts) {

--- a/index.js
+++ b/index.js
@@ -160,9 +160,11 @@ function writeShimPost (target) {
  * of the target program (script or executable).
  *
  * @param {string} target Path to the executable or script.
- * @typedef {{program?: string, additionalArgs: string}} RuntimeInfo If `.program` is `null`,
- * the program may be a binary executable or something and can be called from shells by just its path.
+ * @typedef {object} RuntimeInfo
+ * @property {string|null} [program] If `program` is `null`, the program may
+ * be a binary executable and can be called from shells by just its path.
  * (e.g. `.\foo.exe` in CMD or PowerShell)
+ * @property {string} additionalArgs
  * @return {Promise<RuntimeInfo>} Promise of infomation of runtime of `target`.
  */
 function searchScriptRuntime (target) {

--- a/index.js
+++ b/index.js
@@ -111,11 +111,14 @@ function cmdShim_ (src, to, opts) {
  */
 function writeAllShims (src, to, srcRuntimeInfo, opts) {
   opts = Object.assign({}, DEFAULT_OPTIONS, opts)
-  return Promise.all([
-    [generateShShim, '', true],
-    [generateCmdShim, '.cmd', opts.createCmdFile],
-    [generatePwshShim, '.ps1', opts.createPwshFile]
-  ].map(([generateShimScript, extension, shouldCreate]) => shouldCreate && writeShim(src, to + extension, srcRuntimeInfo, generateShimScript, opts)))
+  const generatorAndExtPairs = [[generateShShim, '']]
+  if (opts.createCmdFile) {
+    generatorAndExtPairs.push([generateCmdShim, '.cmd'])
+  }
+  if (opts.createPwshFile) {
+    generatorAndExtPairs.push([generatePwshShim, '.ps1'])
+  }
+  return Promise.all(generatorAndExtPairs.map(([generateShimScript, extension]) => writeShim(src, to + extension, srcRuntimeInfo, generateShimScript, opts)))
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -78,6 +78,15 @@ function rm (path) {
   return fs.unlink(path).catch(() => {})
 }
 
+/**
+ * Try to create shims **even if `src` is missing**.
+ *
+ * @param {string} src Path to program (executable or script).
+ * @param {string} to Path to shims.
+ * Don't add an extension if you will create multiple types of shims.
+ * @param {Options} opts Options.
+ *
+ */
 function cmdShim_ (src, to, opts) {
   opts = Object.assign({}, DEFAULT_OPTIONS, opts)
   return searchScriptRuntime(src).then((srcRuntimeInfo) => {

--- a/index.js
+++ b/index.js
@@ -370,7 +370,11 @@ function generatePwshShim (src, to, opts) {
   return pwsh
 }
 
-
+/**
+ * Chmod just created shim and make it executable
+ *
+ * @param {string} to Path to shim.
+ */
 function chmodShim (to) {
   return fs.chmod(to, 0o755)
 }

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const DEFAULT_OPTIONS = {
   createPwshFile: true,
   createCmdFile: isWindows()
 }
+/**
+ * Map from extensions of files that this module is frequently used for to their runtime.
+ * @type {Map<string, string>}
+ */
 const extensionToProgramMap = new Map([
   ['.js', 'node'],
   ['.cmd', 'cmd'],

--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ function generateShShim (src, to, opts) {
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.ps1`.
- * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @param {Options} opts Options.
  * @return {string} The content of shim.
  */
 function generatePwshShim (src, to, opts) {

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function writeShimsPreCommon (target) {
  * @param {string} src Path to program (executable or script).
  * @param {string} to Path to shims **without extensions**.
  * Extensions are added for CMD and PowerShell shims.
- * @param {srcRuntimeInfo} srcRuntimeInfo Return value of `await searchScriptRuntime(src)`.
+ * @param {RuntimeInfo} srcRuntimeInfo Return value of `await searchScriptRuntime(src)`.
  * @param {Options} opts Options.
  */
 function writeAllShims (src, to, srcRuntimeInfo, opts) {

--- a/index.js
+++ b/index.js
@@ -94,8 +94,18 @@ function cmdShim_ (src, to, opts) {
     // Append your code here to change the behavior in response to `srcRuntimeInfo`.
 
     // Create 3 shims for (Ba)sh in Cygwin / MSYS, no extension) & CMD (.cmd) & PowerShell (.ps1)
-    return writeAllShims(src, to, srcRuntimeInfo, opts)
+    return writeShimsPreCommon(to).then(() => writeAllShims(src, to, srcRuntimeInfo, opts))
   })
+}
+
+/**
+ * Do processes before **all** shims are created.
+ * This must be called **only once** for one call of `cmdShim(IfExists)`.
+ *
+ * @param {string} target Path of shims that are going to be created.
+ */
+function writeShimsPreCommon (target) {
+  return mkdir(path.dirname(target))
 }
 
 /**
@@ -127,7 +137,7 @@ function writeAllShims (src, to, srcRuntimeInfo, opts) {
  * @param {string} target Path to shim that is going to be created.
  */
 function writeShimPre (target) {
-  return rm(target).then(() => mkdir(path.dirname(target)))
+  return rm(target)
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -143,6 +143,16 @@ function searchScriptRuntime (target) {
     })
 }
 
+/**
+ * Write shim to the file system while executing the pre- and post-processes
+ * defined in `WriteShimPre` and `WriteShimPost`.
+ *
+ * @param {string} src Path to the executable or script.
+ * @param {string} to Path to the (sh) shim(s) that is going to be created.
+ * @param {RuntimeInfo} srcRuntimeInfo Result of `await searchScriptRuntime(src)`.
+ * @param {(src: string, to: string, opts: Options) => string} generateShimScript Generator of shim script.
+ * @param {Options} opts Other options.
+ */
 function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
   const defaultArgs = opts.preserveSymlinks ? '--preserve-symlinks' : ''
   // `Array.prototype.flter` removes ''.

--- a/index.js
+++ b/index.js
@@ -156,15 +156,21 @@ function writeShimPost (target) {
 }
 
 /**
- * Look into runtime (e.g. `node` & `sh` & `pwsh`) and its arguments
- * of the target program (script or executable).
+ * Infomation of runtime and its arguments of the script `target`, defined in the shebang of it.
  *
- * @param {string} target Path to the executable or script.
  * @typedef {object} RuntimeInfo
  * @property {string|null} [program] If `program` is `null`, the program may
  * be a binary executable and can be called from shells by just its path.
  * (e.g. `.\foo.exe` in CMD or PowerShell)
- * @property {string} additionalArgs
+ * @property {string} additionalArgs Additional arguments embedded in the shebang and passed to `program`.
+ * `''` if nothing, unlike `program`.
+ */
+
+/**
+ * Look into runtime (e.g. `node` & `sh` & `pwsh`) and its arguments
+ * of the target program (script or executable).
+ *
+ * @param {string} target Path to the executable or script.
  * @return {Promise<RuntimeInfo>} Promise of infomation of runtime of `target`.
  */
 function searchScriptRuntime (target) {

--- a/index.js
+++ b/index.js
@@ -89,6 +89,17 @@ function cmdShim_ (src, to, opts) {
   })
 }
 
+/**
+ * Write all types (sh & cmd & pwsh) of shims to files.
+ * Extensions (`.cmd` and `.ps1`) are appended to cmd and pwsh shims.
+ *
+ *
+ * @param {string} src Path to program (executable or script).
+ * @param {string} to Path to shims **without extensions**.
+ * Extensions are added for CMD and PowerShell shims.
+ * @param {srcRuntimeInfo} srcRuntimeInfo Return value of `await searchScriptRuntime(src)`.
+ * @param {Options} opts Options.
+ */
 function writeAllShims (src, to, srcRuntimeInfo, opts) {
   opts = Object.assign({}, DEFAULT_OPTIONS, opts)
   return Promise.all([

--- a/index.js
+++ b/index.js
@@ -225,7 +225,8 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
 
 /**
  * Callback functions to generate scripts for shims.
- * @callback ShimGenerator
+ * @callback ShimGenerator Callback functions to generate scripts for shims.
+ *
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim(s) that is going to be created.
  * @param {Options} opts Options.

--- a/index.js
+++ b/index.js
@@ -197,7 +197,8 @@ function searchScriptRuntime (target) {
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the (sh) shim(s) that is going to be created.
  * @param {RuntimeInfo} srcRuntimeInfo Result of `await searchScriptRuntime(src)`.
- * @param {(src: string, to: string, opts: Options) => string} generateShimScript Generator of shim script.
+ * @typedef {(src: string, to: string, opts: Options) => string} ShimGenerator
+ * @param {ShimGenerator} generateShimScript Generator of shim script.
  * @param {Options} opts Other options.
  */
 function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
@@ -218,6 +219,7 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
 /**
  * Generate the content of a shim for CMD.
  *
+ * @type {ShimGenerator}
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.cmd` (or `.bat`).
@@ -269,6 +271,7 @@ function generateCmdShim (src, to, opts) {
 /**
  * Generate the content of a shim for (Ba)sh in, for example, Cygwin and MSYS(2).
  *
+ * @type {ShimGenerator}
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.sh` or to contain no extension.
@@ -340,6 +343,7 @@ function generateShShim (src, to, opts) {
 /**
  * Generate the content of a shim for PowerShell.
  *
+ * @type {ShimGenerator}
  * @param {string} src Path to the executable or script.
  * @param {string} to Path to the shim to be created.
  * It is highly recommended to end with `.ps1`.

--- a/index.js
+++ b/index.js
@@ -215,6 +215,15 @@ function writeShim (src, to, srcRuntimeInfo, generateShimScript, opts) {
     .then(() => writeShimPost(to))
 }
 
+/**
+ * Generate the content of a shim for CMD.
+ *
+ * @param {string} src Path to the executable or script.
+ * @param {string} to Path to the shim to be created.
+ * It is highly recommended to end with `.cmd` (or `.bat`).
+ * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @return {string} The content of shim.
+ */
 function generateCmdShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
   let target = shTarget.split('/').join('\\')
@@ -259,6 +268,15 @@ function generateCmdShim (src, to, opts) {
   return cmd
 }
 
+/**
+ * Generate the content of a shim for (Ba)sh in, for example, Cygwin and MSYS(2).
+ *
+ * @param {string} src Path to the executable or script.
+ * @param {string} to Path to the shim to be created.
+ * It is highly recommended to end with `.sh` or to contain no extension.
+ * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @return {string} The content of shim.
+ */
 function generateShShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
   let target = shTarget.split('/').join('\\')
@@ -326,6 +344,15 @@ function generateShShim (src, to, opts) {
   return sh
 }
 
+/**
+ * Generate the content of a shim for PowerShell.
+ *
+ * @param {string} src Path to the executable or script.
+ * @param {string} to Path to the shim to be created.
+ * It is highly recommended to end with `.ps1`.
+ * @param {opts} opts Options.  It must contain `.prog` and `.args`.
+ * @return {string} The content of shim.
+ */
 function generatePwshShim (src, to, opts) {
   let shTarget = path.relative(path.dirname(to), src)
   let target = shTarget.split('/').join('\\')


### PR DESCRIPTION
# Problems

- `cmdShim_` contains both of processes to remove old shims and to create 3 types of shims.  I suppose they should be seperated.
- `writeShim` contains the process to search for runtime of the target program, which may be a script.  It should be absorbed into a new functions.
- `writeShim_` contains processes to create 3 types of shims, to write all of them at the same time, and to make them executable in Unix by `chmod`.  They should be splitted to different functions.

They make it difficult to test them and to add new features, for example, one to create just a shim `shim.bat` to `another\place\script.bat`.

And there are no documents except for `normalizePathEnvVar` in private functions.

# What I did

- [x] Split sticked features in these functions into different functions.
- [x] Add documents in refactored private functions.
- [x] Make variables in `generate*Shim` (`writeShim_`) simpler (by remove unused one, for example)

# Future plans

- Edit `cmdShim_` to support shims of shims.
- Add new option to allow us to create chained shims (shims of shims) and some code to `cmdShim_` to create them.
- Add unit tests for appended functions.