### PR TITLE
chore: Fix Travis CI build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 end_of_line = lf
 
-[*.{ts,js,json}]
+[*.{ts,js,json,yml,yaml}]
 indent_style = space
 indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 8
-  - 10
+  - '4'
+  - '6'
+  - '8'
+  - '10'
 before_install:
   - curl -L https://unpkg.com/@pnpm/self-installer | node
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 environment:
   matrix:
-    - nodejs_version: 4
-    - nodejs_version: 6
-    - nodejs_version: 8
-    - nodejs_version: 10
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+    - nodejs_version: '10'
 install:
   - ps: Install-Product node $env:nodejs_version
   - curl -L https://unpkg.com/@pnpm/self-installer | node
   - pnpm install
 matrix:
   fast_finish: true
-build: off
+build: 'off'
 version: '{build}'
 test_script:
   - node --version

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test:unit": "tape test/*.js",
-    "test": "standard && npm run test:unit && mos test",
+    "test": "standard && pnpm run test:unit && mos test",
     "md": "mos"
   },
   "files": [


### PR DESCRIPTION
This makes the Travis CI build no longer fail.

---

~~I’ve also re‑enabled testing on Node 4 to make sure we don’t regress Yarn, which depends on this package, which works now that we’re using the pnpm self‑installer.~~

**Edit:** That doesn’t work as `tape‑promise` uses [syntax unsupported in Node 4](https://travis-ci.org/pnpm/cmd-shim/jobs/508533913#L494-L506).