### PR TITLE
improve sh binstubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "is-windows": "^1.0.2",
-    "make-dir": "^3.0.0"
+    "make-dir": "^3.0.0",
+    "strip-indent": "^3.0.0"
   },
   "devDependencies": {
     "@types/is-windows": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mos": "^1.3.1",
     "mos-plugin-readme": "^1.0.4",
     "standard": "^14.0.2",
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.4"
   },
   "engines": {
     "node": ">=8.15"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       "readme"
     ]
   },
+  "standard": {
+    "env": {
+      "jest": true
+    }
+  },
   "jest": {
     "testEnvironment": "node"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   is-windows: 1.0.2
   make-dir: 3.0.0
+  strip-indent: 3.0.0
 devDependencies:
   '@types/is-windows': 0.2.0
   '@types/node': 12.7.2
@@ -3711,6 +3712,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+  /min-indent/1.0.0:
+    dev: false
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
   /minimatch/3.0.4:
     dependencies:
       brace-expansion: 1.1.11
@@ -5477,6 +5484,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
+  /strip-indent/3.0.0:
+    dependencies:
+      min-indent: 1.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
   /strip-json-comments/2.0.1:
     dev: true
     engines:
@@ -6109,4 +6124,5 @@ specifiers:
   mos: ^1.3.1
   mos-plugin-readme: ^1.0.4
   standard: ^14.0.2
+  strip-indent: ^3.0.0
   typescript: ^3.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ devDependencies:
   mos: 1.3.1
   mos-plugin-readme: 1.0.4
   standard: 14.0.2
-  typescript: 3.5.3
+  typescript: 3.7.4
 lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.5.5:
@@ -5740,13 +5740,13 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
-  /typescript/3.5.3:
+  /typescript/3.7.4:
     dev: true
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+      integrity: sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
   /uglify-js/3.6.0:
     dependencies:
       commander: 2.20.0
@@ -6109,4 +6109,4 @@ specifiers:
   mos: ^1.3.1
   mos-plugin-readme: ^1.0.4
   standard: ^14.0.2
-  typescript: ^3.5.3
+  typescript: ^3.7.4

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,18 +398,16 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
         *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
     esac
   `).trim() + '\n\n'
-  const env = opts.nodePath ? `NODE_PATH="${shNodePath}" ` : ''
+  const env = opts.nodePath ? `export NODE_PATH="${shNodePath}"` : ''
 
   if (shLongProg) {
     sh += stripIndent(`
+      ${env}
       if [ -x ${shLongProg} ]; then
-        ${env + shLongProg} ${args} ${shTarget} "$@"
-        ret=$?
+        exec ${shLongProg} ${args} ${shTarget} "$@"
       else\x20
-        ${env + shProg} ${args} ${shTarget} "$@"
-        ret=$?
+        exec ${shProg} ${args} ${shTarget} "$@"
       fi
-      exit $ret
     `).trim() + '\n'
   } else {
     sh += stripIndent(`

--- a/test/test.js
+++ b/test/test.js
@@ -86,13 +86,10 @@ test('env shebang', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node"  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  node  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -146,14 +143,12 @@ test('env shebang with NODE_PATH', async () => {
     '\n    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;' +
     '\nesac' +
     '\n' +
+    '\nexport NODE_PATH="/john/src/node_modules:/bin/node/node_modules"' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  NODE_PATH="/john/src/node_modules:/bin/node/node_modules" "$basedir/node"  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  NODE_PATH="/john/src/node_modules:/bin/node/node_modules" node  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@SET NODE_PATH=\\john\\src\\node_modules;\\bin\\node\\node_modules\r' +
@@ -214,13 +209,10 @@ test('env shebang with default args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node" --preserve-symlinks "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node" --preserve-symlinks "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  node --preserve-symlinks "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node --preserve-symlinks "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -275,13 +267,10 @@ test('env shebang with args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node"  --expose_gc "$basedir/src.env.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  --expose_gc "$basedir/src.env.args" "$@"' +
     '\nelse ' +
-    '\n  node  --expose_gc "$basedir/src.env.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  --expose_gc "$basedir/src.env.args" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -336,13 +325,10 @@ test('explicit shebang', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir//usr/bin/sh" ]; then' +
-    '\n  "$basedir//usr/bin/sh"  "$basedir/src.sh" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir//usr/bin/sh"  "$basedir/src.sh" "$@"' +
     '\nelse ' +
-    '\n  /usr/bin/sh  "$basedir/src.sh" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec /usr/bin/sh  "$basedir/src.sh" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
 
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
@@ -399,13 +385,10 @@ test('explicit shebang with args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir//usr/bin/sh" ]; then' +
-    '\n  "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" "$@"' +
     '\nelse ' +
-    '\n  /usr/bin/sh  -x "$basedir/src.sh.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec /usr/bin/sh  -x "$basedir/src.sh.args" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
 
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(


### PR DESCRIPTION
* use `export NODE_PATH=` to reduce file size
* use `exec` to reduce memory footprint: sh has no reason to be alive after its duty ends
* fix https://github.com/pnpm/pnpm/issues/2272