### PR TITLE
improve sh binstubs (alternate)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,6 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   // else
   //   exec node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
   // fi
-  // exit $ret
 
   let sh = '#!/bin/sh\n'
   sh = sh +

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,12 +380,12 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   //     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
   // esac
   //
+  // export NODE_PATH="<nodepath>"
+  //
   // if [ -x "$basedir/node.exe" ]; then
-  //   "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
-  //   ret=$?
+  //   exec "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
   // else
-  //   node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
-  //   ret=$?
+  //   exec node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
   // fi
   // exit $ret
 
@@ -397,18 +397,15 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
     '    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;\n' +
     'esac\n' +
     '\n'
-  const env = opts.nodePath ? `NODE_PATH="${shNodePath}" ` : ''
+  const env = opts.nodePath ? `export NODE_PATH="${shNodePath}"\n` : ''
 
   if (shLongProg) {
-    sh = sh +
+    sh = sh + env +
       'if [ -x ' + shLongProg + ' ]; then\n' +
-      '  ' + env + shLongProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
-      '  ret=$?\n' +
+      '  exec ' + shLongProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
       'else \n' +
-      '  ' + env + shProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
-      '  ret=$?\n' +
-      'fi\n' +
-      'exit $ret\n'
+      '  exec ' + shProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
+      'fi\n'
   } else {
     sh = sh + env + shProg + ' ' + args + ' ' + shTarget + ' "$@"\n' +
       'exit $?\n'

--- a/test/test.js
+++ b/test/test.js
@@ -86,13 +86,10 @@ test('env shebang', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node"  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  node  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -146,14 +143,12 @@ test('env shebang with NODE_PATH', async () => {
     '\n    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;' +
     '\nesac' +
     '\n' +
+    '\nexport NODE_PATH="/john/src/node_modules:/bin/node/node_modules"' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  NODE_PATH="/john/src/node_modules:/bin/node/node_modules" "$basedir/node"  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  NODE_PATH="/john/src/node_modules:/bin/node/node_modules" node  "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@SET NODE_PATH=\\john\\src\\node_modules;\\bin\\node\\node_modules\r' +
@@ -214,13 +209,10 @@ test('env shebang with default args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node" --preserve-symlinks "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node" --preserve-symlinks "$basedir/src.env" "$@"' +
     '\nelse ' +
-    '\n  node --preserve-symlinks "$basedir/src.env" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node --preserve-symlinks "$basedir/src.env" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -275,13 +267,10 @@ test('env shebang with args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir/node" ]; then' +
-    '\n  "$basedir/node"  --expose_gc "$basedir/src.env.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir/node"  --expose_gc "$basedir/src.env.args" "$@"' +
     '\nelse ' +
-    '\n  node  --expose_gc "$basedir/src.env.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec node  --expose_gc "$basedir/src.env.args" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
     '@IF EXIST "%~dp0\\node.exe" (\r' +
@@ -336,13 +325,10 @@ test('explicit shebang', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir//usr/bin/sh" ]; then' +
-    '\n  "$basedir//usr/bin/sh"  "$basedir/src.sh" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir//usr/bin/sh"  "$basedir/src.sh" "$@"' +
     '\nelse ' +
-    '\n  /usr/bin/sh  "$basedir/src.sh" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec /usr/bin/sh  "$basedir/src.sh" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
 
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
@@ -399,13 +385,10 @@ test('explicit shebang with args', async () => {
     '\nesac' +
     '\n' +
     '\nif [ -x "$basedir//usr/bin/sh" ]; then' +
-    '\n  "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" "$@"' +
     '\nelse ' +
-    '\n  /usr/bin/sh  -x "$basedir/src.sh.args" "$@"' +
-    '\n  ret=$?' +
+    '\n  exec /usr/bin/sh  -x "$basedir/src.sh.args" "$@"' +
     '\nfi' +
-    '\nexit $ret' +
     '\n')
 
   expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(


### PR DESCRIPTION
* use `export NODE_PATH` to reduce file size
* use `exec` to reduce memory footprint: sh has no reason to be alive after its duty ends
* fix https://github.com/pnpm/pnpm/issues/2272