### PR TITLE
Implements prog args

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The same as above, but will just continue if the file does not exist.
 - `opts.nodePath` - _String_ - sets the [NODE_PATH](https://nodejs.org/api/cli.html#cli_node_path_path) env variable.
 - `opts.createCmdFile` - _Boolean_ - is `true` on Windows by default. If true, creates a cmd file.
 - `opts.createPwshFile` - _Boolean_ - is `true` by default. If true, creates a powershell file.
+- `opts.progArgs` - String - optional arguments that will be prepend to any CLI arguments
 
 ```javascript
 const cmdShim = require('@zkochan/cmd-shim')

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ namespace cmdShim {
     /**
      * The arguments to initialize the target process with, before the actual CLI arguments
      */
-    progArgs?: string
+    progArgs?: string[]
 
     /**
      * The value of the $NODE_PATH environment variable.
@@ -329,7 +329,7 @@ function generateCmdShim (src: string, to: string, opts: InternalOptions): strin
     target = quotedPathToTarget
   }
 
-  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
+  let progArgs = opts.progArgs ? `${opts.progArgs.join(` `)} ` : ''
 
   // @IF EXIST "%~dp0\node.exe" (
   //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
@@ -380,7 +380,7 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
     shTarget = quotedPathToTarget
   }
 
-  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
+  let progArgs = opts.progArgs ? `${opts.progArgs.join(` `)} ` : ''
 
   // #!/bin/sh
   // basedir=`dirname "$0"`
@@ -451,7 +451,7 @@ function generatePwshShim (src: string, to: string, opts: InternalOptions): stri
     shTarget = quotedPathToTarget
   }
 
-  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
+  let progArgs = opts.progArgs ? `${opts.progArgs.join(` `)} ` : ''
 
   // #!/usr/bin/env pwsh
   // $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,11 @@ namespace cmdShim {
     args?: string
 
     /**
+     * The arguments to initialize the target process with, before the actual CLI arguments
+     */
+    progArgs?: string
+
+    /**
      * The value of the $NODE_PATH environment variable.
      *
      * The single `string` format is only kept for legacy compatibility,
@@ -324,6 +329,8 @@ function generateCmdShim (src: string, to: string, opts: InternalOptions): strin
     target = quotedPathToTarget
   }
 
+  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
+
   // @IF EXIST "%~dp0\node.exe" (
   //   "%~dp0\node.exe" "%~dp0\.\node_modules\npm\bin\npm-cli.js" %*
   // ) ELSE (
@@ -334,14 +341,14 @@ function generateCmdShim (src: string, to: string, opts: InternalOptions): strin
   let cmd = nodePath ? `@SET NODE_PATH=${nodePath}\r\n` : ''
   if (longProg) {
     cmd += `@IF EXIST ${longProg} (\r\n` +
-      `  ${longProg} ${args} ${target} %*\r\n` +
+      `  ${longProg} ${args} ${target} ${progArgs}%*\r\n` +
       ') ELSE (\r\n' +
       '  @SETLOCAL\r\n' +
       '  @SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
-      `  ${prog} ${args} ${target} %*\r\n` +
+      `  ${prog} ${args} ${target} ${progArgs}%*\r\n` +
       ')'
   } else {
-    cmd += `@${prog} ${args} ${target} %*\r\n`
+    cmd += `@${prog} ${args} ${target} ${progArgs}%*\r\n`
   }
 
   return cmd
@@ -373,6 +380,8 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
     shTarget = quotedPathToTarget
   }
 
+  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
+
   // #!/bin/sh
   // basedir=`dirname "$0"`
   //
@@ -401,12 +410,12 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   if (shLongProg) {
     sh += env +
       `if [ -x ${shLongProg} ]; then\n` +
-      `  exec ${shLongProg} ${args} ${shTarget} "$@"\n` +
+      `  exec ${shLongProg} ${args} ${shTarget} ${progArgs}"$@"\n` +
       'else \n' +
-      `  exec ${shProg} ${args} ${shTarget} "$@"\n` +
+      `  exec ${shProg} ${args} ${shTarget} ${progArgs}"$@"\n` +
       'fi\n'
   } else {
-    sh += `${env}${shProg} ${args} ${shTarget} "$@"\n` +
+    sh += `${env}${shProg} ${args} ${shTarget} ${progArgs}"$@"\n` +
       'exit $?\n'
   }
 
@@ -441,6 +450,8 @@ function generatePwshShim (src: string, to: string, opts: InternalOptions): stri
     pwshLongProg = `"$basedir/${opts.prog}$exe"`
     shTarget = quotedPathToTarget
   }
+
+  let progArgs = opts.progArgs ? `${opts.progArgs} ` : ''
 
   // #!/usr/bin/env pwsh
   // $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
@@ -494,17 +505,17 @@ function generatePwshShim (src: string, to: string, opts: InternalOptions): stri
       `if (Test-Path ${pwshLongProg}) {\n` +
       '  # Support pipeline input\n' +
       '  if ($MyInvocation.ExpectingInput) {\n' +
-      `    $input | & ${pwshLongProg} ${args} ${shTarget} $args\n` +
+      `    $input | & ${pwshLongProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '  } else {\n' +
-      `    & ${pwshLongProg} ${args} ${shTarget} $args\n` +
+      `    & ${pwshLongProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '  }\n' +
       '  $ret=$LASTEXITCODE\n' +
       '} else {\n' +
       '  # Support pipeline input\n' +
       '  if ($MyInvocation.ExpectingInput) {\n' +
-      `    $input | & ${pwshProg} ${args} ${shTarget} $args\n` +
+      `    $input | & ${pwshProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '  } else {\n' +
-      `    & ${pwshProg} ${args} ${shTarget} $args\n` +
+      `    & ${pwshProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '  }\n' +
       '  $ret=$LASTEXITCODE\n' +
       '}\n' +
@@ -514,9 +525,9 @@ function generatePwshShim (src: string, to: string, opts: InternalOptions): stri
     pwsh = pwsh +
       '# Support pipeline input\n' +
       'if ($MyInvocation.ExpectingInput) {\n' +
-      `  $input | & ${pwshProg} ${args} ${shTarget} $args\n` +
+      `  $input | & ${pwshProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '} else {\n' +
-      `  & ${pwshProg} ${args} ${shTarget} $args\n` +
+      `  & ${pwshProg} ${args} ${shTarget} ${progArgs}$args\n` +
       '}\n' +
       (opts.nodePath ? '$env:NODE_PATH=$env_node_path\n' : '') +
       'exit $LASTEXITCODE\n'

--- a/test/test.js
+++ b/test/test.js
@@ -435,7 +435,7 @@ test('explicit shebang with args', async () => {
 test('explicit shebang with prog args', async () => {
   const src = path.resolve(fixtures, 'src.sh.args')
   const to = path.resolve(fixtures, 'sh.args.shim')
-  await cmdShim(src, to, { createCmdFile: true, progArgs: 'hello', fs })
+  await cmdShim(src, to, { createCmdFile: true, progArgs: ['hello'], fs })
   expect(fs.readFileSync(to, 'utf8')).toBe(
     '#!/bin/sh' +
     "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +

--- a/test/test.js
+++ b/test/test.js
@@ -432,6 +432,66 @@ test('explicit shebang with args', async () => {
     '\n')
 })
 
+test('explicit shebang with prog args', async () => {
+  const src = path.resolve(fixtures, 'src.sh.args')
+  const to = path.resolve(fixtures, 'sh.args.shim')
+  await cmdShim(src, to, { createCmdFile: true, progArgs: 'hello', fs })
+  expect(fs.readFileSync(to, 'utf8')).toBe(
+    '#!/bin/sh' +
+    "\nbasedir=$(dirname \"$(echo \"$0\" | sed -e 's,\\\\,/,g')\")" +
+    '\n' +
+    '\ncase `uname` in' +
+    '\n    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;' +
+    '\nesac' +
+    '\n' +
+    '\nif [ -x "$basedir//usr/bin/sh" ]; then' +
+    '\n  exec "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" hello "$@"' +
+    '\nelse ' +
+    '\n  exec /usr/bin/sh  -x "$basedir/src.sh.args" hello "$@"' +
+    '\nfi' +
+    '\n')
+
+  expect(fs.readFileSync(to + '.cmd', 'utf8')).toBe(
+    '@IF EXIST "%~dp0\\/usr/bin/sh.exe" (\r' +
+    '\n  "%~dp0\\/usr/bin/sh.exe"  -x "%~dp0\\src.sh.args" hello %*\r' +
+    '\n) ELSE (\r' +
+    '\n  @SETLOCAL\r' +
+    '\n  @SET PATHEXT=%PATHEXT:;.JS;=;%\r' +
+    '\n  /usr/bin/sh  -x "%~dp0\\src.sh.args" hello %*\r' +
+    '\n)')
+
+  expect(fs.readFileSync(`${to}.ps1`, 'utf8')).toBe(
+    '#!/usr/bin/env pwsh' +
+    '\n$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent' +
+    '\n' +
+    '\n$exe=""' +
+    '\nif ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {' +
+    '\n  # Fix case when both the Windows and Linux builds of Node' +
+    '\n  # are installed in the same directory' +
+    '\n  $exe=".exe"' +
+    '\n}' +
+    '\n$ret=0' +
+    '\nif (Test-Path "$basedir//usr/bin/sh$exe") {' +
+    '\n  # Support pipeline input' +
+    '\n  if ($MyInvocation.ExpectingInput) {' +
+    '\n    $input | & "$basedir//usr/bin/sh$exe"  -x "$basedir/src.sh.args" hello $args' +
+    '\n  } else {' +
+    '\n    & "$basedir//usr/bin/sh$exe"  -x "$basedir/src.sh.args" hello $args' +
+    '\n  }' +
+    '\n  $ret=$LASTEXITCODE' +
+    '\n} else {' +
+    '\n  # Support pipeline input' +
+    '\n  if ($MyInvocation.ExpectingInput) {' +
+    '\n    $input | & "/usr/bin/sh$exe"  -x "$basedir/src.sh.args" hello $args' +
+    '\n  } else {' +
+    '\n    & "/usr/bin/sh$exe"  -x "$basedir/src.sh.args" hello $args' +
+    '\n  }' +
+    '\n  $ret=$LASTEXITCODE' +
+    '\n}' +
+    '\nexit $ret' +
+    '\n')
+})
+
 ;(process.platform === 'win32' ? test : test.skip)('explicit shebang with args, linking to another drive on Windows', async () => {
   const src = path.resolve(fixtures2, 'src.sh.args')
   const to = path.resolve(fixtures, 'sh.args.shim')


### PR DESCRIPTION
I'd like to prepend a static argument to the program argument list, which is currently difficult. This diff adds a new option for this, `progArgs`. The list isn't escaped because the arguments I have in mind are simple and won't need that - might be improved later.