### PR TITLE
fix shebangExpr: ignore -S argument for /usr/bin/env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ import {promisify} from 'util'
 import path = require('path')
 import isWindows = require('is-windows')
 import CMD_EXTENSION = require('cmd-extension')
-const shebangExpr = /^#!\s*(?:\/usr\/bin\/env)?\s*([^ \t]+)(.*)$/
+const shebangExpr = /^#!\s*(?:\/usr\/bin\/env(?:\s+-S\s*)?)?\s*([^ \t]+)(.*)$/
 const DEFAULT_OPTIONS = {
   // Create PowerShell file by default if the option hasn't been specified
   createPwshFile: true,

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -735,3 +735,62 @@ if ($MyInvocation.ExpectingInput) {
 exit $LASTEXITCODE
 "
 `;
+
+exports[`shebang with -S from.env.S.shim 1`] = `
+"#!/bin/sh
+basedir=$(dirname \\"$(echo \\"$0\\" | sed -e 's,\\\\\\\\,/,g')\\")
+
+case \`uname\` in
+    *CYGWIN*) basedir=\`cygpath -w \\"$basedir\\"\`;;
+esac
+
+if [ -x \\"$basedir/node\\" ]; then
+  exec \\"$basedir/node\\"  --expose_gc \\"$basedir/from.env.S\\" \\"$@\\"
+else
+  exec node  --expose_gc \\"$basedir/from.env.S\\" \\"$@\\"
+fi
+"
+`;
+
+exports[`shebang with -S from.env.S.shim.cmd 1`] = `
+"@SETLOCAL
+@IF EXIST \\"%~dp0\\\\node.exe\\" (
+  \\"%~dp0\\\\node.exe\\"  --expose_gc \\"%~dp0\\\\from.env.S\\" %*
+) ELSE (
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  --expose_gc \\"%~dp0\\\\from.env.S\\" %*
+)
+"
+`;
+
+exports[`shebang with -S from.env.S.shim.ps1 1`] = `
+"#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=\\"\\"
+if ($PSVersionTable.PSVersion -lt \\"6.0\\" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=\\".exe\\"
+}
+$ret=0
+if (Test-Path \\"$basedir/node$exe\\") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & \\"$basedir/node$exe\\"  --expose_gc \\"$basedir/from.env.S\\" $args
+  } else {
+    & \\"$basedir/node$exe\\"  --expose_gc \\"$basedir/from.env.S\\" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & \\"node$exe\\"  --expose_gc \\"$basedir/from.env.S\\" $args
+  } else {
+    & \\"node$exe\\"  --expose_gc \\"$basedir/from.env.S\\" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+"
+`;

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,7 +23,8 @@ const fixtureFiles = {
     'src.env': '#!/usr/bin/env node\nconsole.log(/hi/)\n',
     'src.env.args': '#!/usr/bin/env node --expose_gc\ngc()\n',
     'src.sh': '#!/usr/bin/sh\necho hi\n',
-    'src.sh.args': '#!/usr/bin/sh -x\necho hi\n'
+    'src.sh.args': '#!/usr/bin/sh -x\necho hi\n',
+    'from.env.S': '#!/usr/bin/env -S node --expose_gc\ngc()\n'
   },
   [fixtures2]: {
     'src.sh.args': '#!/usr/bin/sh -x\necho hi\n'

--- a/test/test.js
+++ b/test/test.js
@@ -178,3 +178,15 @@ testOnWindows('explicit shebang with args, linking to another drive on Windows',
   testFile(`${to}.cmd`, '\r\n')
   testFile(`${to}.ps1`)
 })
+
+describe('shebang with -S', () => {
+  const src = path.resolve(fixtures, 'from.env.S')
+  const to = path.resolve(fixtures, 'from.env.S.shim')
+  beforeAll(() => {
+    return cmdShim(src, to, { createCmdFile: true, fs })
+  })
+
+  testFile(to)
+  testFile(`${to}.cmd`, '\r\n')
+  testFile(`${to}.ps1`)
+})


### PR DESCRIPTION
fix https://github.com/pnpm/pnpm/issues/5575

upstream issue https://github.com/npm/cmd-shim/issues/54
upstream patch https://github.com/npm/cmd-shim/pull/55

side note: upstream's shebangExpr is more complex, as it can parse env vars
