### PR TITLE
fix: shim non-existent source

### DIFF
--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -736,6 +736,22 @@ exit $LASTEXITCODE
 "
 `;
 
+exports[`no src file missing.shim 1`] = `
+"#!/bin/sh
+basedir=$(dirname \\"$(echo \\"$0\\" | sed -e 's,\\\\\\\\,/,g')\\")
+
+case \`uname\` in
+    *CYGWIN*) basedir=\`cygpath -w \\"$basedir\\"\`;;
+esac
+
+if [ -x \\"$basedir/node\\" ]; then
+  exec \\"$basedir/node\\"  \\"$basedir/missing.js\\" \\"$@\\"
+else
+  exec node  \\"$basedir/missing.js\\" \\"$@\\"
+fi
+"
+`;
+
 exports[`shebang with -S from.env.S.shim 1`] = `
 "#!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -738,16 +738,16 @@ exit $LASTEXITCODE
 
 exports[`no src file missing.shim 1`] = `
 "#!/bin/sh
-basedir=$(dirname \\"$(echo \\"$0\\" | sed -e 's,\\\\\\\\,/,g')\\")
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w \\"$basedir\\"\`;;
+    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
-if [ -x \\"$basedir/node\\" ]; then
-  exec \\"$basedir/node\\"  \\"$basedir/missing.js\\" \\"$@\\"
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/missing.js" "$@"
 else
-  exec node  \\"$basedir/missing.js\\" \\"$@\\"
+  exec node  "$basedir/missing.js" "$@"
 fi
 "
 `;

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,17 @@ function testFile (fileName, lineEnding = '\n') {
   })
 }
 
+describe('no src file', () => {
+  const src = path.resolve(fixtures, 'missing.js')
+  const to = path.resolve(fixtures, 'missing.shim')
+
+  beforeAll(() => {
+    return cmdShim(src, to, { createCmdFile: false, fs })
+  })
+
+  testFile(to)
+})
+
 describe('no cmd file', () => {
   const src = path.resolve(fixtures, 'src.exe')
   const to = path.resolve(fixtures, 'exe.shim')


### PR DESCRIPTION
PNPM has this long-standing issue where pnpm install fails when a package defines a bin that must be compiled first: https://github.com/pnpm/pnpm/issues/1801

In this case the file can't be read and so a shebang can't be determined, and execution fails with error code `ENOENT`. This seems easily solvable. cmd-shim can still fall back to determining the program by using the `extensionToProgramMap`.

This PR is probably incomplete. Not being terribly familiar with the code, I've done my best, but the test is probably incomplete at the very least.