### PR TITLE
Fix generated shell scripts for Cygwin/MSYS2/MinGW

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -440,7 +440,7 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   // case `uname` in
   //     *CYGWIN*|*MINGW*|*MSYS*)
   //         if command -v cygpath > /dev/null 2>&1; then
-  //             basedir=`cygpath -w "$basedir"`;;
+  //             basedir=`cygpath -w "$basedir"`
   //         fi
   //      ;;
   // esac
@@ -460,7 +460,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,11 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   // basedir=`dirname "$0"`
   //
   // case `uname` in
-  //     *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+  //     *CYGWIN*|*MINGW*|*MSYS*)
+  //         if command -v cygpath > /dev/null 2>&1; then
+  //             basedir=`cygpath -w "$basedir"`;;
+  //         fi
+  //      ;;
   // esac
   //
   // export NODE_PATH="<nodepath>"
@@ -454,7 +458,11 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 `

--- a/test/__snapshots__/e2e.test.js.snap
+++ b/test/__snapshots__/e2e.test.js.snap
@@ -5,7 +5,7 @@ exports[`create a command shim for a .exe file 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 "$basedir/foo"   "$@"

--- a/test/__snapshots__/e2e.test.js.snap
+++ b/test/__snapshots__/e2e.test.js.snap
@@ -7,7 +7,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac

--- a/test/__snapshots__/e2e.test.js.snap
+++ b/test/__snapshots__/e2e.test.js.snap
@@ -5,7 +5,11 @@ exports[`create a command shim for a .exe file 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 "$basedir/foo"   "$@"

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -7,7 +7,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -50,7 +50,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -113,7 +113,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -199,7 +199,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -274,7 +274,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -337,7 +337,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -400,7 +400,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -463,7 +463,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -526,7 +526,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -589,7 +589,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -652,7 +652,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -715,7 +715,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -752,7 +752,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac
@@ -795,7 +795,7 @@ basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`;;
+            basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
 esac

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -5,7 +5,11 @@ exports[`custom node executable env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 "/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
@@ -44,7 +48,11 @@ exports[`env shebang env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -103,7 +111,11 @@ exports[`env shebang with NODE_PATH env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
@@ -185,7 +197,11 @@ exports[`env shebang with PATH extending env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 export PATH="/add-to-path:$PATH"
@@ -256,7 +272,11 @@ exports[`env shebang with args env.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -315,7 +335,11 @@ exports[`env shebang with default args env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -374,7 +398,11 @@ exports[`env shebang with no NODE_PATH env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -433,7 +461,11 @@ exports[`explicit shebang sh.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -492,7 +524,11 @@ exports[`explicit shebang with args sh.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -551,7 +587,11 @@ exports[`explicit shebang with args, linking to another drive on Windows sh.args
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -610,7 +650,11 @@ exports[`explicit shebang with prog args sh.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -669,7 +713,11 @@ exports[`no cmd file exe.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 "$basedir/src.exe"   "$@"
@@ -702,7 +750,11 @@ exports[`no shebang exe.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 "$basedir/src.exe"   "$@"
@@ -741,7 +793,11 @@ exports[`shebang with -S from.env.S.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=\`cygpath -w "$basedir"\`;;
+        fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`custom node executable env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 "/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
@@ -44,7 +44,7 @@ exports[`env shebang env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -103,7 +103,7 @@ exports[`env shebang with NODE_PATH env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
@@ -185,7 +185,7 @@ exports[`env shebang with PATH extending env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 export PATH="/add-to-path:$PATH"
@@ -256,7 +256,7 @@ exports[`env shebang with args env.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -315,7 +315,7 @@ exports[`env shebang with default args env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -374,7 +374,7 @@ exports[`env shebang with no NODE_PATH env.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -433,7 +433,7 @@ exports[`explicit shebang sh.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -492,7 +492,7 @@ exports[`explicit shebang with args sh.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -551,7 +551,7 @@ exports[`explicit shebang with args, linking to another drive on Windows sh.args
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -610,7 +610,7 @@ exports[`explicit shebang with prog args sh.args.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -669,7 +669,7 @@ exports[`no cmd file exe.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 "$basedir/src.exe"   "$@"
@@ -702,7 +702,7 @@ exports[`no shebang exe.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 "$basedir/src.exe"   "$@"
@@ -741,7 +741,7 @@ exports[`shebang with -S from.env.S.shim 1`] = `
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
-    *CYGWIN*) basedir=\`cygpath -w "$basedir"\`;;
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=\`cygpath -w "$basedir"\`;;
 esac
 
 if [ -x "$basedir/node" ]; then


### PR DESCRIPTION
Reference: https://github.com/npm/cmd-shim/pull/30

This PR is based on the PR above, and also fixes the `NODE_PATH` pnpm additionally seems to rely on that npm does not. `pnpm run test` completes with no issues, though I am unsure how to build the entirety of `pnpm` with these changes for further testing.