### PR TITLE
fix: use realpath for building path of bin-file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,13 +458,29 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
 
   let sh = `\
 #!/bin/sh
-basedir=$(dirname "$(realpath "$0" | sed -e 's,\\\\,/,g')")
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -458,7 +458,7 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
 
   let sh = `\
 #!/bin/sh
-basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir=$(dirname "$(realpath "$0" | sed -e 's,\\\\,/,g')")
 
 case \`uname\` in
     *CYGWIN*|*MINGW*|*MSYS*)

--- a/test/__snapshots__/e2e.test.js.snap
+++ b/test/__snapshots__/e2e.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`create a command shim for a .exe file 1`] = `
 "#!/bin/sh

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`batch script bat.shim 1`] = `
 "#!/bin/sh
@@ -9,6 +9,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -73,6 +89,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 "/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
@@ -115,6 +147,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -178,6 +226,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -265,6 +329,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 export PATH="/add-to-path:$PATH"
@@ -340,6 +420,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -402,6 +498,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -466,6 +578,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 if [ -x "$basedir/node" ]; then
@@ -529,6 +657,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 if [ -x "$basedir//usr/bin/sh" ]; then
@@ -591,6 +735,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -664,17 +824,6 @@ else
 fi
 `;
 
-exports[`explicit shebang with args, linking to another drive on Windows sh.args.shim.CMD 1`] = `
-"@SETLOCAL
-@IF EXIST "%~dp0\\/usr/bin/sh.exe" (
-  "%~dp0\\/usr/bin/sh.exe"  -x "J:\\cmd-shim\\fixtures\\src.sh.args" %*
-) ELSE (
-  @SET PATHEXT=%PATHEXT:;.JS;=;%
-  /usr/bin/sh  -x "J:\\cmd-shim\\fixtures\\src.sh.args" %*
-)
-"
-`;
-
 exports[`explicit shebang with args, linking to another drive on Windows sh.args.shim.ps1 1`] = `
 "#!/usr/bin/env pwsh
 $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
@@ -716,6 +865,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -780,6 +945,22 @@ case \`uname\` in
             basedir=\`cygpath -w "$basedir"\`
         fi
     ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
+    ;;
 esac
 
 "$basedir/src.exe"   "$@"
@@ -816,6 +997,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 
@@ -859,6 +1056,22 @@ case \`uname\` in
         if command -v cygpath > /dev/null 2>&1; then
             basedir=\`cygpath -w "$basedir"\`
         fi
+    ;;
+    *)
+      if command -v realpath >/dev/null 2>&1; then
+          basedir=\`realpath "$basedir"\`
+      elif command -v readlink >/dev/null 2>&1; then
+          # some systems has the readlink, but doesn't have "-f" flag
+          if readlink -f "$basedir" >/dev/null 2>&1; then
+               basedir=\`readlink -f "$basedir"\`
+          else
+               basedir=\`readlink "$basedir"\`
+          fi
+      elif command -v perl >/dev/null 2>&1; then
+          basedir=\`perl -e 'use Cwd "abs_path"; print abs_path(shift)' "$basedir"\`
+      elif [[ $basedir != /* ]]; then
+          basedir="$PWD/\${basedir#./}"
+      fi
     ;;
 esac
 


### PR DESCRIPTION
if use virtual-store outside of node_modules and node_modules outside of build dir, bin path can be broke

for example we have this hypothetical  structure
```
~/Projects/app/node_modules -> ~/.cache/modules/app/node_modules

~/.cache/modules/app/node_modules/eslint -> ~/.cache/vstore/app/eslint@8.56.0/node_modules/eslint

~/.cache/modules/app/node_modules/.bin/eslint =>
$0 => node_modules/.bin/eslint
basedir => node_modules/.bin
...
node  "node_modules/.bin/../../../../vstore/app/eslint@8.56.0/node_modules/eslint/bin/eslint.js"

=> error, module not found
```

module not found, because path is incorrect
`~/Projects/app/node_modules/.bin/../../../../vstore/app/eslint@8.56.0/node_modules/eslint/bin/eslint.js`

with realpath it will fixed
```
realpath $0 => ~/.cache/modules/app/node_modules/.bin/eslint
basedir => ~/.cache/modules/app/node_modules/.bin
node ~/.cache/modules/app/node_modules/.bin/../../../../vstore/app/eslint@8.56.0/node_modules/eslint/bin/eslint.js

=> no errors
```


ps: we have node_modules outside of our build dir for some optimisation