### PR TITLE
fix: use 'exec' in binstub

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -525,7 +525,7 @@ fi
 `
   } else {
     sh += `\
-${shProg} ${args} ${shTarget} ${progArgs}"$@"
+exec ${shProg} ${args} ${shTarget} ${progArgs}"$@"
 exit $?
 `
   }

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, test, snapshot } from 'node:test'
@@ -11,6 +11,7 @@ import tempy from 'tempy'
 import { cmdShim } from '../index.js'
 
 const describeOnWindows = process.platform === 'win32' ? describe : describe.skip
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe
 
 describeOnWindows('create a command shim for a .exe file', () => {
   test('shim files', async (t) => {
@@ -54,6 +55,37 @@ describeOnWindows('sh shim wrapping a .cmd target invoked from Git Bash', () => 
       r.stdout,
       /Microsoft Windows \[Version/,
       'cmd.exe started interactively — the /C switch was dropped'
+    )
+  })
+})
+
+describeOnPosix('sh shim binstub uses exec', () => {
+  // Regression for the binstub bug: without `exec`, the shell process
+  // wraps the wrapped binary, so signals sent to the shim do not reach
+  // the wrapped process and the binary's PID differs from the shim's
+  // spawn PID. With `exec`, the shell process is replaced in place and
+  // the wrapped binary inherits the shim's PID.
+  test('wrapped binary inherits the shim\'s PID (proves exec replaced the shell)', async () => {
+    const tempDir = tempy.directory()
+    // process.execPath is a no-shebang native binary, so cmdShim hits the
+    // non-shLongProg branch of generateShShim — the one that needs `exec`.
+    const shim = path.join(tempDir, 'shim')
+    await cmdShim(process.execPath, shim)
+
+    const proc = spawn('/bin/sh', [shim, '-p', 'process.pid'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const shimPid = proc.pid
+    let stdout = ''
+    proc.stdout.on('data', (chunk) => { stdout += chunk })
+    const exitCode = await new Promise((resolve) => proc.on('exit', resolve))
+
+    assert.equal(exitCode, 0, `shim exited ${exitCode}; stdout=${stdout}`)
+    const reportedPid = Number(stdout.trim())
+    assert.equal(
+      reportedPid,
+      shimPid,
+      `expected child to inherit shim PID via exec — got reported=${reportedPid}, shim=${shimPid}`
     )
   })
 })

--- a/test/e2e.test.js.snapshot
+++ b/test/e2e.test.js.snapshot
@@ -11,7 +11,7 @@ case \`uname\` in
     ;;
 esac
 
-"$basedir/foo"   "$@"
+exec "$basedir/foo"   "$@"
 exit $?
 
 `;

--- a/test/test.js.snapshot
+++ b/test/test.js.snapshot
@@ -77,7 +77,7 @@ case \`uname\` in
     ;;
 esac
 
-"/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
+exec "/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
 exit $?
 
 `;
@@ -818,7 +818,7 @@ case \`uname\` in
     ;;
 esac
 
-"$basedir/src.exe"   "$@"
+exec "$basedir/src.exe"   "$@"
 exit $?
 
 `;
@@ -857,7 +857,7 @@ case \`uname\` in
     ;;
 esac
 
-"$basedir/src.exe"   "$@"
+exec "$basedir/src.exe"   "$@"
 exit $?
 
 `;


### PR DESCRIPTION
When cmd-shim is used to create a wrapper for `node` (or any other binary with no shebang and no recognized extension), you cannot kill the wrapped process by killing the process spawned by invoking the shim, because the sh binstub doesn't use `exec`.

Commit [1033be3](https://github.com/npm/cmd-shim/commit/1033be3) ("fix: improve sh binstubs", 2020-01-16) added `exec` to the `shLongProg` code path, but for some reason didn't add it to the **non-`shLongProg`** (`else`) path — the one taken when `opts.prog` is null (e.g. a `.exe` or other extension-less binary). This PR adds `exec` to that branch so signal delivery and PID inheritance behave consistently across both paths.

## Test plan

- Existing unit-test snapshots updated to reflect the new `exec`-prefixed output (3 snapshots in `test.js.snapshot`, 1 in `e2e.test.js.snapshot`).
- New POSIX e2e regression test that wraps `process.execPath` (a no-shebang native binary, exercising the non-`shLongProg` branch), spawns the shim, and asserts the wrapped binary's `process.pid` equals the shim's spawn PID — which is only possible when the shell `exec`s into the target. Manually verified: 7/59 tests fail when the `exec` change is reverted, 59/59 pass with it.
- CI green on ubuntu / windows × Node 22 / 24.

Rebased onto current `main` (which includes the recently merged MSYS escape fix from #55).
