### PR TITLE
fix: queue retries on EMFILE by routing default fs through @pnpm/fs.graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "@pnpm/fs.graceful-fs": "^1100.1.0",
-    "cmd-extension": "^1.0.2"
+    "cmd-extension": "^1.0.2",
+    "graceful-fs": "^4.2.11"
   },
   "devDependencies": {
+    "@types/graceful-fs": "^4.1.9",
     "@types/node": "^18.19.87",
     "memfs": "^3.5.3",
     "tempy": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zkochan/cmd-shim",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Used in pnpm for command line application support",
   "type": "module",
   "author": {
@@ -30,6 +30,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
+    "@pnpm/fs.graceful-fs": "^1100.1.0",
     "cmd-extension": "^1.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,13 @@ importers:
       cmd-extension:
         specifier: ^1.0.2
         version: 1.0.2
+      graceful-fs:
+        specifier: ^4.2.11
+        version: 4.2.11
     devDependencies:
+      '@types/graceful-fs':
+        specifier: ^4.1.9
+        version: 4.1.9
       '@types/node':
         specifier: ^18.19.87
         version: 18.19.87
@@ -229,6 +235,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@types/graceful-fs@4.1.9':
+    resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
   '@types/node@18.19.87':
     resolution: {integrity: sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==}
@@ -442,6 +451,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@types/graceful-fs@4.1.9':
+    dependencies:
+      '@types/node': 18.19.87
 
   '@types/node@18.19.87':
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,22 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import gfs from '@pnpm/fs.graceful-fs'
+import { promisify } from 'node:util'
+import gfs from 'graceful-fs'
 import CMD_EXTENSION from 'cmd-extension'
+
+// graceful-fs patches the callback API with EMFILE retry/queueing.
+// fs.promises bypasses those patches, so we promisify the patched
+// callback functions instead. This is the same pattern @pnpm/fs.graceful-fs
+// uses, inlined here to avoid a workspace dependency.
+const gfsPromises = {
+  chmod: promisify(gfs.chmod),
+  mkdir: promisify(gfs.mkdir),
+  readFile: promisify(gfs.readFile),
+  stat: promisify(gfs.stat),
+  unlink: promisify(gfs.unlink),
+  writeFile: promisify(gfs.writeFile),
+}
 
 export interface Options {
   /**
@@ -122,12 +136,8 @@ const extensionToProgramMap = new Map([
 
 function ingestOptions (opts?: Options): InternalOptions {
   const opts_ = {...DEFAULT_OPTIONS, ...opts} as InternalOptions
-  // Use @pnpm/fs.graceful-fs by default to queue retries on EMFILE/ENFILE.
-  // Native fs.promises bypasses the userland patches that graceful-fs installs
-  // on the callback API, so under high concurrency (many bins linked at once)
-  // it surfaces EMFILE instead of waiting for a free file descriptor.
   // Tests and other callers may still inject a custom fs (e.g. memfs).
-  opts_.fs_ = opts_.fs ? opts_.fs.promises : (gfs as unknown as FsPromises)
+  opts_.fs_ = opts_.fs ? opts_.fs.promises : (gfsPromises as unknown as FsPromises)
   return opts_
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import gfs from '@pnpm/fs.graceful-fs'
 import CMD_EXTENSION from 'cmd-extension'
 
 export interface Options {
@@ -104,7 +105,6 @@ const DEFAULT_OPTIONS = {
   // Create PowerShell file by default if the option hasn't been specified
   createPwshFile: true,
   createCmdFile: isWindows,
-  fs,
 }
 /**
  * Map from extensions of files that this module is frequently used for to their runtime.
@@ -122,8 +122,12 @@ const extensionToProgramMap = new Map([
 
 function ingestOptions (opts?: Options): InternalOptions {
   const opts_ = {...DEFAULT_OPTIONS, ...opts} as InternalOptions
-  const fsImpl = opts_.fs
-  opts_.fs_ = fsImpl.promises
+  // Use @pnpm/fs.graceful-fs by default to queue retries on EMFILE/ENFILE.
+  // Native fs.promises bypasses the userland patches that graceful-fs installs
+  // on the callback API, so under high concurrency (many bins linked at once)
+  // it surfaces EMFILE instead of waiting for a free file descriptor.
+  // Tests and other callers may still inject a custom fs (e.g. memfs).
+  opts_.fs_ = opts_.fs ? opts_.fs.promises : (gfs as unknown as FsPromises)
   return opts_
 }
 


### PR DESCRIPTION
## Summary

- Restores EMFILE retry/queueing for the default `fs` implementation by switching from native `fs.promises` to `graceful-fs` (promisified internally).
- Custom `fs` injection (used by the test suite with memfs) still works via `opts.fs`.
- Bumps version to `9.0.1`.

Fixes pnpm/pnpm#11412.

## Background

In 8.0.0 this package dropped `graceful-fs` in its ESM rewrite and switched to native `fs.promises`. `fs.promises` bypasses the userland patches that `graceful-fs` installs on the callback API, so under high concurrency (e.g. linking bins for hundreds of workspace projects in parallel) the writes surface `EMFILE` instead of waiting for a free file descriptor.

We re-add `graceful-fs` and call `promisify(gfs.X)` so the queueing applies to the promise API too — same pattern `@pnpm/fs.graceful-fs` uses, inlined here so this fix can ship without waiting on a `@pnpm/fs.graceful-fs` release.

## Test plan

- [x] `node --test test/test.js test/e2e.test.js` — all 58 tests pass on macOS
- [ ] verify EMFILE no longer reproduces on the Azure SDK case from pnpm/pnpm#11412 (Windows)