### PR TITLE
fix(sh): escape `/C` so MSYS doesn't drop the cmd switch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -325,6 +325,15 @@ function getExeExtension (): string {
 }
 
 /**
+ * Prefix bare `/C` / `/K` switches with an extra `/` so MSYS / Git Bash
+ * passes them through to cmd.exe unchanged instead of converting them to
+ * `C:\` / `K:\` paths. See {@link generateShShim} for context.
+ */
+function escapeMsysCmdSwitches (args: string): string {
+  return args.replace(/(^|\s)\/([CcKk])(\s|$)/g, '$1//$2$3')
+}
+
+/**
  * Write shim to the file system while executing the pre- and post-processes
  * defined in `WriteShimPre` and `WriteShimPost`.
  *
@@ -433,7 +442,13 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   let shLongProg
   shTarget = shTarget.split('\\').join('/')
   const quotedPathToTarget = path.isAbsolute(shTarget) ? `"${shTarget}"` : `"$basedir/${shTarget}"`
-  let args = opts.args || ''
+  // Escape leading `/` on single-letter switches like `/C` (passed to cmd.exe
+  // for `.cmd`/`.bat` targets). When Git Bash / MSYS launches a native Win32
+  // process, arguments that look like POSIX paths are translated — a bare
+  // `/C` becomes `C:\`, which drops the switch and leaves cmd.exe running
+  // interactively. Prefixing with `//` is the MSYS escape: it survives the
+  // translation and reaches cmd.exe as `/C`.
+  let args = escapeMsysCmdSwitches(opts.args || '')
   const shNodePath = normalizePathEnvVar(opts.nodePath).posix
   if (!shProg) {
     shProg = quotedPathToTarget

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,13 +442,17 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   let shLongProg
   shTarget = shTarget.split('\\').join('/')
   const quotedPathToTarget = path.isAbsolute(shTarget) ? `"${shTarget}"` : `"$basedir/${shTarget}"`
-  // Escape leading `/` on single-letter switches like `/C` (passed to cmd.exe
-  // for `.cmd`/`.bat` targets). When Git Bash / MSYS launches a native Win32
-  // process, arguments that look like POSIX paths are translated — a bare
-  // `/C` becomes `C:\`, which drops the switch and leaves cmd.exe running
-  // interactively. Prefixing with `//` is the MSYS escape: it survives the
-  // translation and reaches cmd.exe as `/C`.
-  let args = escapeMsysCmdSwitches(opts.args || '')
+  // For `.cmd`/`.bat` targets the runtime is `cmd` and args is `/C`. When
+  // Git Bash / MSYS launches a native Win32 process, arguments that look
+  // like POSIX paths are translated — a bare `/C` becomes `C:\`, which
+  // drops the switch and leaves cmd.exe running interactively. Prefixing
+  // with `//` is the MSYS escape: it survives the translation and reaches
+  // cmd.exe as `/C`. Scoped to the cmd runtime so shebang-derived `/C`
+  // args on other shims are passed through unchanged.
+  let args = opts.args || ''
+  if (opts.prog === 'cmd' || opts.prog === 'cmd.exe') {
+    args = escapeMsysCmdSwitches(args)
+  }
   const shNodePath = normalizePathEnvVar(opts.nodePath).posix
   if (!shProg) {
     shProg = quotedPathToTarget

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, test, snapshot } from 'node:test'
@@ -20,5 +21,39 @@ describeOnWindows('create a command shim for a .exe file', () => {
     t.assert.snapshot(stripMarker(fs.readFileSync(path.join(tempDir, 'dest'), 'utf-8')))
     t.assert.snapshot(fs.readFileSync(path.join(tempDir, 'dest.cmd'), 'utf-8'))
     t.assert.snapshot(fs.readFileSync(path.join(tempDir, 'dest.ps1'), 'utf-8'))
+  })
+})
+
+describeOnWindows('sh shim wrapping a .cmd target invoked from Git Bash', () => {
+  // Regression for the MSYS path-translation bug: Git Bash rewrites a bare
+  // `/C` argument to `C:\` before launching cmd.exe, dropping the switch
+  // and leaving cmd.exe interactive. The fix escapes it as `//C` so MSYS
+  // passes it through.
+  test('runs the wrapped batch script and captures its output', async () => {
+    const tempDir = tempy.directory()
+    const target = path.join(tempDir, 'src.cmd')
+    fs.writeFileSync(target, '@echo HELLO_FROM_CMD\r\n', 'utf8')
+    const shim = path.join(tempDir, 'shim')
+    await cmdShim(target, shim)
+
+    // Invoke the sh shim via Git Bash. If `/C` survives MSYS translation,
+    // cmd.exe runs src.cmd and prints HELLO_FROM_CMD; if it gets rewritten
+    // to a drive path, cmd.exe starts interactively and dumps its banner
+    // (`Microsoft Windows [Version ...]`) instead.
+    const bash = process.env.PROGRAMFILES
+      ? path.join(process.env.PROGRAMFILES, 'Git', 'bin', 'bash.exe')
+      : 'bash'
+    const r = spawnSync(bash, ['--noprofile', '--norc', shim], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    assert.equal(r.status, 0, `bash exited ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    assert.match(r.stdout, /HELLO_FROM_CMD/, `expected script output, got:\n${r.stdout}`)
+    assert.doesNotMatch(
+      r.stdout,
+      /Microsoft Windows \[Version/,
+      'cmd.exe started interactively — the /C switch was dropped'
+    )
   })
 })

--- a/test/test.js.snapshot
+++ b/test/test.js.snapshot
@@ -12,9 +12,9 @@ case \`uname\` in
 esac
 
 if [ -x "$basedir/cmd" ]; then
-  exec "$basedir/cmd" /C "$basedir/src.bat" "$@"
+  exec "$basedir/cmd" //C "$basedir/src.bat" "$@"
 else
-  exec cmd /C "$basedir/src.bat" "$@"
+  exec cmd //C "$basedir/src.bat" "$@"
 fi
 
 `;


### PR DESCRIPTION
## Summary

The sh shim generated for a `.cmd` / `.bat` target runs the script via:

```sh
exec cmd /C "<path>" "$@"
```

Under Git Bash (MSYS), the path-conversion layer that runs when bash spawns a native Win32 process rewrites arguments matching POSIX-path heuristics. A bare `/C` is treated as a path and rewritten to `C:\`. `cmd.exe` then never sees the `/C` flag — it starts interactively and reads the remainder of the calling script as input until EOF.

Prefixing with `//` is the MSYS escape: `//C` survives the translation and reaches `cmd.exe` as `/C`. The cmd shim is unaffected (cmd.exe doesn't path-translate its own args), so the change is scoped to `generateShShim`.

## Repro

In a Git Bash shell on Windows after this PR is reverted, any cmd-shim-wrapped batch script reproduces the bug. Concretely, in a pnpm Windows CI run:

```bash
# pn is a sh shim that does: exec cmd /C "...pn.cmd" "$@"
$ pn exec node -v
Microsoft Windows [Version 10.0.26100.32690]
(c) Microsoft Corporation. All rights reserved.

D:\a\pnpm\pnpm>
```

(That's `cmd.exe`'s interactive banner and prompt. The next line of the calling script is then fed to cmd as input.)

After live-patching the shim with `sed 's,/C ,//C ,'`, the same call returns `v22.13.0` as expected. Full diagnostic + proof: https://github.com/pnpm/pnpm/actions/runs/25701484608/job/75462777365

## Test plan

- [x] Existing unit/e2e tests pass (`node --test test/test.js test/e2e.test.js`, 58/58)
- [x] Snapshot updated to reflect the `/C → //C` change on the two relevant sh-shim lines (no other snapshots touched)
- [x] End-to-end validated on Windows CI by patching the live shim with `sed` — `pn exec node -v` returns the expected version after the patch
- [ ] Once released, bump `@zkochan/cmd-shim` in pnpm and re-run the Windows test job

## Context

Bug introduced in #46 (which added the `/C` switch). #48 expanded MSYS detection in the same shim but didn't touch the args. Affects any `.cmd` / `.bat` target invoked via the sh shim from Git Bash / MSYS / Cygwin.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure shims preserve cmd.exe switches under MSYS/Git Bash by escaping bare /C and /K when targeting cmd, so wrapped commands run reliably.

* **Tests**
  * Updated snapshots to reflect escaped switch behavior.
  * Added a Windows/Git Bash regression test to verify shims preserve cmd switches and produce expected output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/cmd-shim/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->