### PR TITLE
fix(sh shim): support running Windows binaries from wsl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -442,6 +442,8 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
   let shLongProg
   shTarget = shTarget.split('\\').join('/')
   const quotedPathToTarget = path.isAbsolute(shTarget) ? `"${shTarget}"` : `"$basedir/${shTarget}"`
+  const quotedPathToTarget_win = path.isAbsolute(shTarget) ? `"${shTarget}"` : `"$basedir_win/${shTarget}"`
+  let shTarget_win
   // For `.cmd`/`.bat` targets the runtime is `cmd` and args is `/C`. When
   // Git Bash / MSYS launches a native Win32 process, arguments that look
   // like POSIX paths are translated — a bare `/C` becomes `C:\`, which
@@ -460,43 +462,68 @@ function generateShShim (src: string, to: string, opts: InternalOptions): string
     shTarget = ''
   } else if (opts.prog === 'node' && opts.nodeExecPath) {
     shProg = `"${opts.nodeExecPath}"`
-    shTarget = quotedPathToTarget
+    shTarget = /\.exe$/.test(opts.nodeExecPath) ? quotedPathToTarget_win : quotedPathToTarget
   } else {
     shLongProg = `"$basedir/${opts.prog}"`
     shTarget = quotedPathToTarget
+    shTarget_win = quotedPathToTarget_win
   }
 
   let progArgs = opts.progArgs ? `${opts.progArgs.join(` `)} ` : ''
 
   // #!/bin/sh
-  // basedir=`dirname "$0"`
+  // basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+  // basedir_win="$basedir"
   //
-  // case `uname` in
-  //     *CYGWIN*|*MINGW*|*MSYS*)
-  //         if command -v cygpath > /dev/null 2>&1; then
-  //             basedir=`cygpath -w "$basedir"`
-  //         fi
-  //      ;;
+  // case `uname -a` in
+  //   *CYGWIN*|*MINGW*|*MSYS*)
+  //     if command -v cygpath > /dev/null 2>&1; then
+  //       basedir=`cygpath -w "$basedir"`
+  //       basedir_win="$basedir"
+  //     fi
+  //   ;;
+  //   *WSL2*)
+  //     if command -v wslpath > /dev/null 2>&1; then
+  //       basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+  //       if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+  //         basedir_win="$basedir"
+  //       fi
+  //     fi
+  //   ;;
   // esac
   //
   // export NODE_PATH="<nodepath>"
   //
   // if [ -x "$basedir/node.exe" ]; then
-  //   exec "$basedir/node.exe" "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+  //   exec "$basedir/node.exe"  "$basedir_win/node_modules/npm/bin/npm-cli.js" "$@"
+  // elif [ -x "$basedir/node" ]; then
+  //   exec "$basedir/node"  "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+  // elif [ -x node ]; then
+  //   exec node  "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
   // else
-  //   exec node "$basedir/node_modules/npm/bin/npm-cli.js" "$@"
+  //   exec node.exe  "$basedir_win/node_modules/npm/bin/npm-cli.js" "$@"
   // fi
 
   let sh = `\
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 `
@@ -517,10 +544,14 @@ fi
 
   if (shLongProg) {
     sh += `\
-if [ -x ${shLongProg} ]; then
+if [ -x ${shLongProg.replace(/"$/, '.exe"')} ]; then
+  exec ${shLongProg.replace(/"$/, '.exe"')} ${args} ${shTarget_win} ${progArgs}"$@"
+elif [ -x ${shLongProg} ]; then
   exec ${shLongProg} ${args} ${shTarget} ${progArgs}"$@"
-else
+elif [ -x ${shProg} ]; then
   exec ${shProg} ${args} ${shTarget} ${progArgs}"$@"
+else
+  exec ${shProg}.exe ${args} ${shTarget_win} ${progArgs}"$@"
 fi
 `
   } else {

--- a/test/e2e.test.js.snapshot
+++ b/test/e2e.test.js.snapshot
@@ -2,13 +2,23 @@ exports[`create a command shim for a .exe file > shim files 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/foo"   "$@"

--- a/test/test.js.snapshot
+++ b/test/test.js.snapshot
@@ -2,19 +2,33 @@ exports[`batch script > shim files > bat.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/cmd" ]; then
+if [ -x "$basedir/cmd.exe" ]; then
+  exec "$basedir/cmd.exe" //C "$basedir_win/src.bat" "$@"
+elif [ -x "$basedir/cmd" ]; then
   exec "$basedir/cmd" //C "$basedir/src.bat" "$@"
-else
+elif [ -x cmd ]; then
   exec cmd //C "$basedir/src.bat" "$@"
+else
+  exec cmd.exe //C "$basedir_win/src.bat" "$@"
 fi
 
 `;
@@ -68,13 +82,23 @@ exports[`custom node executable > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 exec "/.pnpm/nodejs/16.0.0/node"  "$basedir/src.env" "$@"
@@ -114,19 +138,33 @@ exports[`env shebang > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  "$basedir_win/src.env" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/src.env" "$@"
-else
+elif [ -x node ]; then
   exec node  "$basedir/src.env" "$@"
+else
+  exec node.exe  "$basedir_win/src.env" "$@"
 fi
 
 `;
@@ -180,13 +218,23 @@ exports[`env shebang with NODE_PATH > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 if [ -z "$NODE_PATH" ]; then
@@ -194,10 +242,14 @@ if [ -z "$NODE_PATH" ]; then
 else
   export NODE_PATH="/john/src/node_modules:/bin/node/node_modules:$NODE_PATH"
 fi
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  "$basedir_win/src.env" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/src.env" "$@"
-else
+elif [ -x node ]; then
   exec node  "$basedir/src.env" "$@"
+else
+  exec node.exe  "$basedir_win/src.env" "$@"
 fi
 
 `;
@@ -269,20 +321,34 @@ exports[`env shebang with PATH extending > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 export PATH="/add-to-path:$PATH"
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  "$basedir_win/src.env" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/src.env" "$@"
-else
+elif [ -x node ]; then
   exec node  "$basedir/src.env" "$@"
+else
+  exec node.exe  "$basedir_win/src.env" "$@"
 fi
 
 `;
@@ -347,19 +413,33 @@ exports[`env shebang with args > shim files > env.args.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  --expose_gc "$basedir_win/src.env.args" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  --expose_gc "$basedir/src.env.args" "$@"
-else
+elif [ -x node ]; then
   exec node  --expose_gc "$basedir/src.env.args" "$@"
+else
+  exec node.exe  --expose_gc "$basedir_win/src.env.args" "$@"
 fi
 
 `;
@@ -413,19 +493,33 @@ exports[`env shebang with default args > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe" --preserve-symlinks "$basedir_win/src.env" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node" --preserve-symlinks "$basedir/src.env" "$@"
-else
+elif [ -x node ]; then
   exec node --preserve-symlinks "$basedir/src.env" "$@"
+else
+  exec node.exe --preserve-symlinks "$basedir_win/src.env" "$@"
 fi
 
 `;
@@ -479,19 +573,33 @@ exports[`env shebang with no NODE_PATH > shim files > env.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  "$basedir_win/src.env" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/src.env" "$@"
-else
+elif [ -x node ]; then
   exec node  "$basedir/src.env" "$@"
+else
+  exec node.exe  "$basedir_win/src.env" "$@"
 fi
 
 `;
@@ -545,19 +653,33 @@ exports[`explicit shebang > shim files > sh.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
+if [ -x "$basedir//usr/bin/sh.exe" ]; then
+  exec "$basedir//usr/bin/sh.exe"  "$basedir_win/src.sh" "$@"
+elif [ -x "$basedir//usr/bin/sh" ]; then
   exec "$basedir//usr/bin/sh"  "$basedir/src.sh" "$@"
-else
+elif [ -x /usr/bin/sh ]; then
   exec /usr/bin/sh  "$basedir/src.sh" "$@"
+else
+  exec /usr/bin/sh.exe  "$basedir_win/src.sh" "$@"
 fi
 
 `;
@@ -611,19 +733,33 @@ exports[`explicit shebang with args > shim files > sh.args.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
+if [ -x "$basedir//usr/bin/sh.exe" ]; then
+  exec "$basedir//usr/bin/sh.exe"  -x "$basedir_win/src.sh.args" "$@"
+elif [ -x "$basedir//usr/bin/sh" ]; then
   exec "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" "$@"
-else
+elif [ -x /usr/bin/sh ]; then
   exec /usr/bin/sh  -x "$basedir/src.sh.args" "$@"
+else
+  exec /usr/bin/sh.exe  -x "$basedir_win/src.sh.args" "$@"
 fi
 
 `;
@@ -677,19 +813,33 @@ exports[`explicit shebang with args, linking to another drive on Windows > shim 
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
+if [ -x "$basedir//usr/bin/sh.exe" ]; then
+  exec "$basedir//usr/bin/sh.exe"  -x "J:/cmd-shim/fixtures/src.sh.args" "$@"
+elif [ -x "$basedir//usr/bin/sh" ]; then
   exec "$basedir//usr/bin/sh"  -x "J:/cmd-shim/fixtures/src.sh.args" "$@"
-else
+elif [ -x /usr/bin/sh ]; then
   exec /usr/bin/sh  -x "J:/cmd-shim/fixtures/src.sh.args" "$@"
+else
+  exec /usr/bin/sh.exe  -x "J:/cmd-shim/fixtures/src.sh.args" "$@"
 fi
 
 `;
@@ -743,19 +893,33 @@ exports[`explicit shebang with prog args > shim files > sh.args.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir//usr/bin/sh" ]; then
+if [ -x "$basedir//usr/bin/sh.exe" ]; then
+  exec "$basedir//usr/bin/sh.exe"  -x "$basedir_win/src.sh.args" hello "$@"
+elif [ -x "$basedir//usr/bin/sh" ]; then
   exec "$basedir//usr/bin/sh"  -x "$basedir/src.sh.args" hello "$@"
-else
+elif [ -x /usr/bin/sh ]; then
   exec /usr/bin/sh  -x "$basedir/src.sh.args" hello "$@"
+else
+  exec /usr/bin/sh.exe  -x "$basedir_win/src.sh.args" hello "$@"
 fi
 
 `;
@@ -809,13 +973,23 @@ exports[`no cmd file > shim files > exe.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/src.exe"   "$@"
@@ -848,13 +1022,23 @@ exports[`no shebang > shim files > exe.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
 exec "$basedir/src.exe"   "$@"
@@ -894,19 +1078,33 @@ exports[`shebang with -S > shim files > from.env.s.shim 1`] = `
 
 #!/bin/sh
 basedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")
+basedir_win="$basedir"
 
-case \`uname\` in
-    *CYGWIN*|*MINGW*|*MSYS*)
-        if command -v cygpath > /dev/null 2>&1; then
-            basedir=\`cygpath -w "$basedir"\`
-        fi
-    ;;
+case \`uname -a\` in
+  *CYGWIN*|*MINGW*|*MSYS*)
+    if command -v cygpath > /dev/null 2>&1; then
+      basedir=\`cygpath -w "$basedir"\`
+      basedir_win="$basedir"
+    fi
+  ;;
+  *WSL2*)
+    if command -v wslpath > /dev/null 2>&1; then
+      basedir_win="$(wslpath -w "$basedir" 2> /dev/null)"
+      if [ $? -ne 0 ] || [ -z "$basedir_win" ]; then
+        basedir_win="$basedir"
+      fi
+    fi
+  ;;
 esac
 
-if [ -x "$basedir/node" ]; then
+if [ -x "$basedir/node.exe" ]; then
+  exec "$basedir/node.exe"  --expose_gc "$basedir_win/from.env.S" "$@"
+elif [ -x "$basedir/node" ]; then
   exec "$basedir/node"  --expose_gc "$basedir/from.env.S" "$@"
-else
+elif [ -x node ]; then
   exec node  --expose_gc "$basedir/from.env.S" "$@"
+else
+  exec node.exe  --expose_gc "$basedir_win/from.env.S" "$@"
 fi
 
 `;


### PR DESCRIPTION
add the same changes as npm/cmd-shim#178, but when the prog does not end with the Windows `.exe` extension keep the passed parameter in its linux-form path, because on this fork, prog can be a posix binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Windows and WSL environment path handling in generated shell shims for improved compatibility with Cygwin, MSYS, and WSL2 scenarios.
  * Updated shell shim generation to correctly resolve and execute targets in Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->